### PR TITLE
Invoke-WebRequest -UseBasicParsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Version | Description | Date | Author
 -|-|-|-
+0.1.00007 | updated Invoke-OpsGenieWebRequest InvokeParams with UseBasicParsing for use on devices without IE First Run | 2022-06-16 | Brad Hemsley
 0.1.00006 | added Project URI to module manifest | 2022-01-20 | Josh Burkard
 0.1.00005 | moving public and private functions to differnet folders | 2022-01-10 | Josh Burkard
 0.1.00004 | simplified all function through use a separate function Invoke-OpsGenieWebRequest to control general web request parameters Proxy, ProxyCredentials and wait | 2021-12-14 | Josh Burkard

--- a/Code/Private/Invoke-OpsGenieWebRequest.ps1
+++ b/Code/Private/Invoke-OpsGenieWebRequest.ps1
@@ -192,9 +192,10 @@
                 # "Authorization" = "GenieKey $($APIKey)a"
                 "Authorization" = "GenieKey $APIKey"
             }
-            'Uri'         = $URI
-            'ContentType' = 'application/json'
-            'Method'      = $Method
+            'Uri'               = $URI
+            'ContentType'       = 'application/json'
+            'Method'            = $Method
+            'UseBasicParsing'   = $true
         }
 
         if ( ( [boolean]$PostParams ) -and ( $Method -notin @('GET') ) ) {

--- a/OpsGenie/OpsGenie.psd1
+++ b/OpsGenie/OpsGenie.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OpsGenie.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.6'
+ModuleVersion = '0.1.7'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/OpsGenie/OpsGenie.psm1
+++ b/OpsGenie/OpsGenie.psm1
@@ -2736,9 +2736,10 @@ function Invoke-OpsGenieWebRequest {
                 # "Authorization" = "GenieKey $($APIKey)a"
                 "Authorization" = "GenieKey $APIKey"
             }
-            'Uri'         = $URI
-            'ContentType' = 'application/json'
-            'Method'      = $Method
+            'Uri'             = $URI
+            'ContentType'     = 'application/json'
+            'Method'          = $Method
+            'UseBasicParsing' = $true
         }
 
         if ( ( [boolean]$PostParams ) -and ( $Method -notin @('GET') ) ) {


### PR DESCRIPTION
The UseBasicParsing parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.